### PR TITLE
fix(webview): guard external-link launches with try/catch

### DIFF
--- a/app/src/main/java/org/androidlabs/applistbackup/docs/DocsViewerActivity.kt
+++ b/app/src/main/java/org/androidlabs/applistbackup/docs/DocsViewerActivity.kt
@@ -1,10 +1,12 @@
 package org.androidlabs.applistbackup.docs
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Bundle
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -66,7 +68,15 @@ fun WebViewComposable(filename: String, modifier: Modifier = Modifier) {
                 ): Boolean {
                     request?.url?.let { url ->
                         val intent = Intent(Intent.ACTION_VIEW, url)
-                        context.startActivity(intent)
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: ActivityNotFoundException) {
+                            Toast.makeText(
+                                context,
+                                R.string.no_app_to_open_link,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
                         return true
                     }
                     return false

--- a/app/src/main/java/org/androidlabs/applistbackup/reader/BackupWebView.kt
+++ b/app/src/main/java/org/androidlabs/applistbackup/reader/BackupWebView.kt
@@ -1,6 +1,7 @@
 package org.androidlabs.applistbackup.reader
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
@@ -9,6 +10,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,6 +29,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.androidlabs.applistbackup.R
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -72,7 +75,17 @@ fun BackupWebView(
                             coroutineScope.launch(Dispatchers.IO) {
                                 val intent = Intent(Intent.ACTION_VIEW, url)
                                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                context.startActivity(intent)
+                                try {
+                                    context.startActivity(intent)
+                                } catch (e: ActivityNotFoundException) {
+                                    withContext(Dispatchers.Main) {
+                                        Toast.makeText(
+                                            context,
+                                            R.string.no_app_to_open_link,
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
+                                }
                             }
                             return true
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name">AppListBackup</string>
+    <string name="no_app_to_open_link">No app available to open this link</string>
     <string name="appwidget_text">Backup now</string>
     <string name="appwidget_text_in_progress">Backing up</string>
     <string name="app_widget_description">This widget allow you to create backup immediately.</string>


### PR DESCRIPTION
Closes #75.

`DocsViewerActivity` and `BackupWebView` both route tapped links to the system browser with raw `context.startActivity(intent)` calls inside `shouldOverrideUrlLoading`. If nothing on the device handles the link (no browser, custom scheme, etc.) the call raises `ActivityNotFoundException` and the host crashes mid-tap. In `BackupWebView` the call sits inside a `Dispatchers.IO` coroutine, so the failure brings the process down even more abruptly.

Wrap both launches in `try { ... } catch (ActivityNotFoundException) { ... }` and fall back to a short Toast (`no_app_to_open_link`). On the `BackupWebView` side the Toast is wrapped in `withContext(Dispatchers.Main)` since the catch fires on `Dispatchers.IO`.

Adds the matching `no_app_to_open_link` string so the message stays translatable. Happy path is unchanged.
